### PR TITLE
Require cl at compile time

### DIFF
--- a/org-wc.el
+++ b/org-wc.el
@@ -22,7 +22,8 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'org))
+(eval-when-compile (require 'org)
+                   (require 'cl))
 
 (defun org-wc-in-heading-line ()
   "Is point in a line starting with `*'?"


### PR DESCRIPTION
I didn't realize before, because I require 'cl in my .emacs file, but you use incf which comes from cl.
