### PR TITLE
Ignore comment tree

### DIFF
--- a/org-wc.el
+++ b/org-wc.el
@@ -47,6 +47,11 @@
   :type '(repeat string)
   :safe #'org-wc-list-of-strings-p)
 
+(defcustom org-wc-ignore-commented-trees t
+  "Ignore trees with COMMENT-prefix if non-nil."
+  :type 'boolean
+  :safe #'booleanp)
+
 (defcustom org-wc-ignored-link-types nil
   "Link types which won't be counted as a word"
   :type '(repeat string)
@@ -101,10 +106,10 @@ LaTeX macros are counted as 1 word."
         (cond
          ;; Ignore heading lines, and sections with org-wc-ignored-tags
          ((org-wc-in-heading-line)
-          (let ((tags (org-get-tags-at)))
-            (if (cl-intersection org-wc-ignored-tags tags :test #'string=)
-                (outline-next-heading)
-              (forward-line))))
+          (if (or (and org-wc-ignore-commented-trees (org-in-commented-heading-p))
+                  (cl-intersection org-wc-ignored-tags (org-get-tags-at) :test #'string=))
+              (org-end-of-subtree t t)
+            (forward-line)))
          ;; Ignore most blocks.
          ((when (save-excursion
                   (move-beginning-of-line 1)

--- a/org-wc.el
+++ b/org-wc.el
@@ -112,7 +112,7 @@ LaTeX macros are counted as 1 word."
             (forward-line)))
          ;; Ignore most blocks.
          ((when (save-excursion
-                  (move-beginning-of-line 1)
+                  (beginning-of-line 1)
                   (looking-at org-block-regexp))
             (if (member (match-string 1) org-wc-blocks-to-count)
                 (progn ;; go inside block and subtract count of end line


### PR DESCRIPTION
- The option for skipping commented trees is set to t by default,
  because that seems reasonable and expected.
- When encountering a tree to be skipped, make sure to not iterate
  through its subtrees unnecessarily.

I also included an obvious bug fix (for stuff I added earlier) in this PR.

One issue with all this is when calling `org-wc-display`. The algorithm for displaying counts traverses trees backwards whereas the counting of each tree proceeds forwards (counting through each subtree multiple times if I’m not mistaken, this could be made faster at some time by "adding up" tree counts and not going down again, but it would require a bit of thinking and rewriting at some time).

This also means that. Because each subtree is narrowed when counted in `org-wc-count-subtrees` the detection of whether it is part of an ignored tree (`org-in-commented-heading-p` and `org-get-tags-at` actually checks the hierarchy upwards (also a possible performance problem)) fails. This means that subtrees of trees which should be ignored gets counted and displayed (but not included in the total count). See screenshot below. I guess this is ok.

![skarmbild fran 2018-04-09 15-46-11](https://user-images.githubusercontent.com/846411/38501522-834e18d8-3c0d-11e8-8921-c5af4fa6a29f.png)
