### PR TITLE
Default link option (on top of #17)

### DIFF
--- a/org-wc.el
+++ b/org-wc.el
@@ -47,6 +47,11 @@
   :type '(repeat string)
   :safe #'org-wc-list-of-strings-p)
 
+(defcustom org-wc-ignore-commented-trees t
+  "Ignore trees with COMMENT-prefix if non-nil."
+  :type 'boolean
+  :safe #'booleanp)
+
 (defcustom org-wc-ignored-link-types nil
   "Link types which won't be counted as a word"
   :type '(repeat string)
@@ -101,10 +106,10 @@ LaTeX macros are counted as 1 word."
         (cond
          ;; Ignore heading lines, and sections with org-wc-ignored-tags
          ((org-wc-in-heading-line)
-          (let ((tags (org-get-tags-at)))
-            (if (cl-intersection org-wc-ignored-tags tags :test #'string=)
-                (outline-next-heading)
-              (forward-line))))
+          (if (or (and org-wc-ignore-commented-trees (org-in-commented-heading-p))
+                  (cl-intersection org-wc-ignored-tags (org-get-tags-at) :test #'string=))
+              (org-end-of-subtree t t)
+            (forward-line)))
          ;; Ignore most blocks.
          ((when (save-excursion
                   (move-beginning-of-line 1)

--- a/org-wc.el
+++ b/org-wc.el
@@ -112,7 +112,7 @@ LaTeX macros are counted as 1 word."
             (forward-line)))
          ;; Ignore most blocks.
          ((when (save-excursion
-                  (move-beginning-of-line 1)
+                  (beginning-of-line 1)
                   (looking-at org-block-regexp))
             (if (member (match-string 1) org-wc-blocks-to-count)
                 (progn ;; go inside block and subtract count of end line


### PR DESCRIPTION
This pull request incorporates #17 but additionally customizes the link options as discussed in #15.

An important enhancement on the way is the functionality added in 91c2009. In the limited tests I have done with some random links, drawers blocks and latex macros, this seems to ensure much more consistent behaviour. But it’s beginning to feel slightly hackish as well. 

(I’m starting to think about implementing word-counting on top of the parsed buffer in org-element, would be cool, don’t know if it would be fast. Would also take time to do).