### PR TITLE
Use correct check for headlines from org

### DIFF
--- a/org-wc.el
+++ b/org-wc.el
@@ -98,10 +98,6 @@ This is applied to any link type not specified in any of
 (defun org-wc-list-of-strings-p (arg)
   (cl-every #'stringp arg))
 
-(defun org-wc-in-heading-line ()
-  "Is point in a line starting with `*'?"
-  (equal (char-after (point-at-bol)) ?*))
-
 ;;;###autoload
 (defun org-word-count (beg end)
   "Report the number of words in the Org mode buffer or selected region.
@@ -130,7 +126,7 @@ LaTeX macros are counted as 1 word. "
       (while (< (point) end)
         (cond
          ;; Ignore heading lines, and sections with org-wc-ignored-tags
-         ((org-wc-in-heading-line)
+         ((org-at-heading-p)
           (if (or (and org-wc-ignore-commented-trees (org-in-commented-heading-p))
                   (cl-intersection org-wc-ignored-tags (org-get-tags-at) :test #'string=))
               (org-end-of-subtree t t)


### PR DESCRIPTION
It’s not enough for a line to start with * for it to be counted as a
headline. We can have text lines starting with bold text in ordinary
paragraphs.

----
This was the second issue that struck me with my quotes today. I had these quote blocks for formatted interview transcripts, and they were not counted 🙂.

```
#+begin_quote
*Me*: Saying something.\\
*Interviewee*: Responding to it...
#+end_quote

```

I have not tested whether this is slower on large files yet. I value accuracy more than speed, but this may conflict with the goal stated in the readme: “The design goal is to be really fast, rather than to count exactly”